### PR TITLE
Add nographic param to qemu

### DIFF
--- a/boot-in-kvm.sh
+++ b/boot-in-kvm.sh
@@ -25,7 +25,8 @@ else
  -net nic,model=virtio -net user,hostfwd=tcp::8022-:22 \
  -drive file=/usr/share/OVMF/OVMF_CODE.fd,if=pflash,format=raw,unit=0,readonly=on \
  -drive file=$IMG,cache=none,format=raw,id=disk1,if=none \
- -device virtio-blk-pci,drive=disk1,bootindex=1 -machine accel=kvm
+ -device virtio-blk-pci,drive=disk1,bootindex=1 -machine accel=kvm \
+ -nographic
    else
         echo $OS "is not a supported os"
    fi


### PR DESCRIPTION
Adding the nographic param for qemu reduces resource consumption by not launching a virtual display window. console-conf still appears in the invoking terminal, and user I/O response can actually improve, as it seems qemu sometimes is not very responsive.